### PR TITLE
feat: rename assert to expect

### DIFF
--- a/.capter/errors.yml
+++ b/.capter/errors.yml
@@ -5,18 +5,18 @@ steps:
     url: https://fake-api.capter.io/api/errors/500
     method: GET
     assertions:
-      - !assert status to_equal 500
+      - !expect status to_equal 500
 
   - name: 404 error
     id: posts
     url: https://fake-api.capter.io/api/errors/404
     method: GET
     assertions:
-      - !assert status to_equal 404
+      - !expect status to_equal 404
 
   - name: 301 error
     id: posts
     url: https://fake-api.capter.io/api/errors/301
     method: GET
     assertions:
-      - !assert status to_equal 301
+      - !expect status to_equal 301

--- a/.capter/graphql.yml
+++ b/.capter/graphql.yml
@@ -13,9 +13,9 @@ steps:
           }
         }
     assertions:
-      - !assert status to_equal 200
-      - !assert headers.content-type to_contain application/json
-      - !assert body.data.posts to_be_array
+      - !expect status to_equal 200
+      - !expect headers.content-type to_contain application/json
+      - !expect body.data.posts to_be_array
 
   - name: fetch one post
     id: post
@@ -31,5 +31,5 @@ steps:
       variables:
         id: ${{ posts.response.body.data.posts.1.id }}
     assertions:
-      - !assert status to_equal 200
-      - !assert body.data.post.id to_equal 1
+      - !expect status to_equal 200
+      - !expect body.data.post.id to_equal 1

--- a/.capter/posts.yml
+++ b/.capter/posts.yml
@@ -9,16 +9,16 @@ steps:
     url: https://fake-api.capter.io/api/posts
     method: GET
     assertions:
-      - !assert status to_equal 200
-      - !!assert status to_equal 500
-      - !assert headers.content-type to_contain application/json
-      - !assert duration to_be_below 1000
-      - !assert duration to_be_above ${{ env.DURATION }}
-      - !assert body to_be_array
-      - !assert body to_have_length 50
-      - !assert body.0.id to_equal ${{ mask env.POST_ID }}
-      - !!assert body.0.title to_be_empty
-      - !!assert body.0.title to_equal this is not the title
+      - !expect status to_equal 200
+      - !!expect status to_equal 500
+      - !expect headers.content-type to_contain application/json
+      - !expect duration to_be_below 1000
+      - !expect duration to_be_above ${{ env.DURATION }}
+      - !expect body to_be_array
+      - !expect body to_have_length 50
+      - !expect body.0.id to_equal ${{ mask env.POST_ID }}
+      - !!expect body.0.title to_be_empty
+      - !!expect body.0.title to_equal this is not the title
     options:
       mask:
         - title
@@ -29,9 +29,9 @@ steps:
     url: https://fake-api.capter.io/api/posts/1
     method: GET
     assertions:
-      - !assert status to_equal 200
-      - !assert body.content to_match dicta dolor ut qui
-      - !!assert body.id to_match 5
+      - !expect status to_equal 200
+      - !expect body.content to_match dicta dolor ut qui
+      - !!expect body.id to_match 5
 
   - name: fetch all posts from author
     url: https://fake-api.capter.io/api/posts
@@ -45,8 +45,8 @@ steps:
           - ${{ post.response.body.authorId }}
           - ${{ mask post.response.body.authorId }}
     assertions:
-      - !assert status to_equal 200
-      - !assert body.0.authorId to_equal ${{ mask post.response.body.id }}
+      - !expect status to_equal 200
+      - !expect body.0.authorId to_equal ${{ mask post.response.body.id }}
 
   - name: fetch posts by user with id 20
     url: https://fake-api.capter.io/api/posts
@@ -54,13 +54,13 @@ steps:
     query:
       authorId: 20
     assertions:
-      - !assert status to_equal 200
-      - !assert body.0.authorId to_be_undefined
+      - !expect status to_equal 200
+      - !expect body.0.authorId to_be_undefined
 
   - name: fetch author with id from env vars
     url: https://fake-api.capter.io/api/authors/${{ env.AUTHOR_ID }}
     method: GET
     skip: true
     assertions:
-      - !assert status to_equal 200
-      - !assert body.id to_equal ${{ env.AUTHOR_ID }}
+      - !expect status to_equal 200
+      - !expect body.id to_equal ${{ env.AUTHOR_ID }}

--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@ steps:
     id: products
     url: ${{ env.URL }}/api/products
     assertions:
-      - !assert status to_equal 200
-      - !assert body to_be_array
+      - !expect status to_equal 200
+      - !expect body to_be_array
 
   - name: fetch first product
     url: ${{ env.URL }}/api/posts/${{ products.response.body.0.id }}
     assertions:
-      - !assert body.id to_equal ${{ products.response.body.0.id }}
+      - !expect body.id to_equal ${{ products.response.body.0.id }}
 ```
 
 Then run the CLI:

--- a/installers/npm/README.md
+++ b/installers/npm/README.md
@@ -29,13 +29,13 @@ steps:
     id: products
     url: ${{ env.URL }}/api/products
     assertions:
-      - !assert status to_equal 200
-      - !assert body to_be_array
+      - !expect status to_equal 200
+      - !expect body to_be_array
 
   - name: fetch first product
     url: ${{ env.URL }}/api/posts/${{ products.response.body.0.id }}
     assertions:
-      - !assert body.id to_equal ${{ products.response.body.0.id }}
+      - !expect body.id to_equal ${{ products.response.body.0.id }}
 ```
 
 Then run the CLI:

--- a/src/workflow/config.rs
+++ b/src/workflow/config.rs
@@ -45,8 +45,8 @@ pub struct WorkflowConfigStep {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[allow(non_camel_case_types)]
 pub enum WorkflowConfigAssertion {
-    assert(String),
-    assert_not(String),
+    expect(String),
+    expect_not(String),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -95,9 +95,9 @@ impl WorkflowConfig {
     }
 
     pub fn from_yaml(yaml: String) -> Result<WorkflowConfig, serde_yaml::Error> {
-        // we use a custom tag !!assert, which yaml-serde currently can't parse
-        // so we need to replace it with !assert_not manually before parsing
-        let yaml = str::replace(&yaml, "!!assert", "!assert_not");
+        // we use a custom tag !!expect, which yaml-serde currently can't parse
+        // so we need to replace it with !expect_not manually before parsing
+        let yaml = str::replace(&yaml, "!!expect", "!expect_not");
 
         serde_yaml::from_str(&yaml)
     }
@@ -124,12 +124,12 @@ mod tests {
                 id: test
                 url: http://localhost:3002/test
                 assertions:
-                  - !assert status equal 200
+                  - !expect status equal 200
               - name: step 2
                 id: test
                 url: http://localhost:3002/test/1
                 assertions:
-                  - !assert status equal 200
+                  - !expect status equal 200
             "
         };
         let config = WorkflowConfig::from_yaml(yaml.into()).unwrap();
@@ -159,7 +159,7 @@ mod tests {
             steps:
               - name: step 1
                 assertions:
-                  - !assert status equal 200
+                  - !expect status equal 200
             "
         };
         WorkflowConfig::from_yaml(yaml.into()).unwrap();

--- a/src/workflow/response.rs
+++ b/src/workflow/response.rs
@@ -237,10 +237,10 @@ mod tests {
         let mut response = ResponseData::from_result(result, 1000);
 
         let assertions = vec![
-            WorkflowConfigAssertion::assert("status to_equal 200".to_string()),
-            WorkflowConfigAssertion::assert("body.hello to_equal world".to_string()),
-            WorkflowConfigAssertion::assert("headers.test-header to_equal test-value".to_string()),
-            WorkflowConfigAssertion::assert("duration to_equal 500".to_string()),
+            WorkflowConfigAssertion::expect("status to_equal 200".to_string()),
+            WorkflowConfigAssertion::expect("body.hello to_equal world".to_string()),
+            WorkflowConfigAssertion::expect("headers.test-header to_equal test-value".to_string()),
+            WorkflowConfigAssertion::expect("duration to_equal 500".to_string()),
         ];
 
         let assertion_results = response.assert(&assertions, &json!({}));

--- a/src/workflow/workflow_result.rs
+++ b/src/workflow/workflow_result.rs
@@ -169,9 +169,9 @@ mod tests {
                 id: test
                 url: {url}/test
                 assertions:
-                  - !assert status to_equal 200
-                  - !assert body.0.id to_equal 1
-                  - !assert body.5.id to_equal 5
+                  - !expect status to_equal 200
+                  - !expect body.0.id to_equal 1
+                  - !expect body.5.id to_equal 5
               - name: step 2
                 url: {url}/test/{path}
                 query:
@@ -181,8 +181,8 @@ mod tests {
                 body:
                   id: {path}
                 assertions:
-                  - !assert status to_equal 200
-                  - !assert body.hello to_equal world
+                  - !expect status to_equal 200
+                  - !expect body.hello to_equal world
             ",
             url = url,
             path = "${{ test.response.body.0.id }}"


### PR DESCRIPTION
## Overview

- Renamed the `!assert` YAML tag to `!expect`

## Details

Since we are going for *plain English* assertions, it looks a lot better with `expect` than `assert`.

```yaml
# old
assertions:
  - !assert body.id to_equal 5

# new
assertions:
  - !expect body.id to_equal 5
```

## Checklist

Remove options that are not relevant.

- [ ] I have updated the documentation
