### PR TITLE
feat: timeout and user agent

### DIFF
--- a/src/cli.yml
+++ b/src/cli.yml
@@ -20,6 +20,11 @@ subcommands:
             help: post the run to a url after completion
             value_name: URL
             takes_value: true
+        - timeout:
+            long: timeout
+            help: how long to wait for a connection
+            value_name: SECONDS
+            takes_value: true
         - skip-git:
             long: skip-git
             help: don't pass any git information to the webhook

--- a/src/ui/ui.rs
+++ b/src/ui/ui.rs
@@ -1,4 +1,7 @@
-use crate::workflow::{run_source::RunSource, WorkflowConfig};
+use crate::{
+    workflow::{run_source::RunSource, WorkflowConfig},
+    CliOptions,
+};
 use crossterm::{
     execute,
     style::{Attribute, Print, SetAttribute},
@@ -25,13 +28,17 @@ pub struct TerminalUi {
 }
 
 impl TerminalUi {
-    pub fn new(configs: &Vec<WorkflowConfig>, source: &RunSource, is_debug: bool) -> TerminalUi {
-        let is_tty = match is_debug {
+    pub fn new(
+        configs: &Vec<WorkflowConfig>,
+        source: &RunSource,
+        cli_options: &CliOptions,
+    ) -> TerminalUi {
+        let is_tty = match cli_options.is_debug {
             true => false,
             false => stdout().is_tty(),
         };
 
-        if is_debug {
+        if cli_options.is_debug {
             TerminalUi::print_run_source(source);
         }
 
@@ -53,7 +60,7 @@ impl TerminalUi {
             skipped_workflows_count: 0,
             workflow_count,
             step_count,
-            is_debug,
+            is_debug: cli_options.is_debug,
         }
     }
 

--- a/src/utils/http_request.rs
+++ b/src/utils/http_request.rs
@@ -1,6 +1,9 @@
 use serde_json::json;
 use serde_yaml::Value;
-use std::{env, time::Instant};
+use std::{
+    env,
+    time::{Duration, Instant},
+};
 
 /// Utility to make http requests.
 /// Wrapper on top of ureq.
@@ -13,8 +16,11 @@ pub struct HttpRequest {
 impl HttpRequest {
     /// Create a new HttpRequest. You can add headers, query and body to it
     /// before calling `.call()`.
-    pub fn new(url: String, method: String) -> HttpRequest {
-        let request = ureq::request(&method, &url).set(
+    pub fn new(url: String, method: String, timeout: u64) -> HttpRequest {
+        let agent = ureq::AgentBuilder::new()
+            .timeout_connect(Duration::from_secs(timeout))
+            .build();
+        let request = agent.request(&method, &url).set(
             "User-Agent",
             &format!("capter/{}", env!("CARGO_PKG_VERSION")),
         );
@@ -105,7 +111,7 @@ mod tests {
             .with_body(r#"{"hello": "world"}"#)
             .create();
 
-        let mut request = HttpRequest::new(format!("{}/test", url), "GET".into());
+        let mut request = HttpRequest::new(format!("{}/test", url), "GET".into(), 30);
         let response = request.call();
 
         match response {
@@ -129,7 +135,7 @@ mod tests {
             .with_status(200)
             .create();
 
-        let mut request = HttpRequest::new(format!("{}/test", url), "GET".into());
+        let mut request = HttpRequest::new(format!("{}/test", url), "GET".into(), 30);
 
         let yaml = indoc! {"
             ---
@@ -167,7 +173,7 @@ mod tests {
             .with_status(200)
             .create();
 
-        let mut request = HttpRequest::new(format!("{}/test", url), "GET".into());
+        let mut request = HttpRequest::new(format!("{}/test", url), "GET".into(), 30);
 
         let yaml = indoc! {"
             ---

--- a/src/workflow/request.rs
+++ b/src/workflow/request.rs
@@ -35,6 +35,7 @@ pub struct Request {
     query: CompiledValue,
     body: CompiledValue,
     response: Option<ResponseData>,
+    timeout: u64,
 }
 
 #[derive(Debug, Serialize, Clone)]
@@ -60,6 +61,7 @@ impl Request {
         workflow_config: &WorkflowConfig,
         step_index: i32,
         workflow_data: &Value,
+        timeout: u64,
     ) -> Request {
         let step = workflow_config
             .steps
@@ -82,6 +84,7 @@ impl Request {
             body,
             headers,
             step_index,
+            timeout,
             method: method.unwrap_or("GET".to_string()),
             created_at: Utc::now(),
             step: step.to_owned(),
@@ -95,7 +98,7 @@ impl Request {
     /// be called before doing any assertions.
     pub fn call(&mut self) -> Option<ResponseData> {
         let data = self.data();
-        let mut request = HttpRequest::new(data.url, data.method);
+        let mut request = HttpRequest::new(data.url, data.method, self.timeout);
 
         // add query
         if let Some(query) = &data.query {

--- a/src/workflow/run_source.rs
+++ b/src/workflow/run_source.rs
@@ -1,3 +1,4 @@
+use crate::CliOptions;
 use last_git_commit::LastGitCommit;
 use serde::Serialize;
 
@@ -30,7 +31,7 @@ pub struct RunSource {
 }
 
 impl RunSource {
-    pub fn new(skip_git: bool) -> RunSource {
+    pub fn new(cli_option: &CliOptions) -> RunSource {
         let ci_info = ci_info::get();
 
         let mut source = RunSource {
@@ -38,7 +39,7 @@ impl RunSource {
         };
 
         // only collect git information if we're allowed to
-        if skip_git == false {
+        if cli_option.skip_git == false {
             let lgc = LastGitCommit::new().build();
             if let Ok(lgc) = lgc {
                 source.branch = Some(lgc.branch().clone());

--- a/src/workflow/workflow_result.rs
+++ b/src/workflow/workflow_result.rs
@@ -1,3 +1,4 @@
+use crate::CliOptions;
 use crate::{
     assert::AssertionResultData,
     workflow::{Request, RequestData, WorkflowConfig},
@@ -39,6 +40,7 @@ impl WorkflowResult {
     ///
     /// Use the callback argument to get continous updates from the run.
     pub fn from_config(
+        cli_options: &CliOptions,
         config: &WorkflowConfig,
         mut callback: impl FnMut(CallbackEvent),
     ) -> Result<WorkflowResult, Box<dyn std::error::Error>> {
@@ -82,7 +84,7 @@ impl WorkflowResult {
                 continue;
             }
 
-            let mut request = Request::new(config, step_index, &workflow_data);
+            let mut request = Request::new(config, step_index, &workflow_data, cli_options.timeout);
 
             // add it to workflow_data if id is set
             if let Some(id) = &step.id {
@@ -192,7 +194,8 @@ mod tests {
 
         match workflow_config {
             Ok(workflow_config) => {
-                let result = WorkflowResult::from_config(&workflow_config, |_| {});
+                let result =
+                    WorkflowResult::from_config(&CliOptions::default(), &workflow_config, |_| {});
                 let result = result.unwrap();
                 let response1 = result.requests[0].response.to_owned().unwrap();
                 let response2 = result.requests[1].response.to_owned().unwrap();


### PR DESCRIPTION
## Overview

- Set the user agent to capter
- Add timeout option to CLI

## Details

#### Set the user agent to capter

To make sure people know where the requests are coming for we want to to be transparent that Capter is the one making the requests.

#### Add timeout option to CLI

When running the tests in CI you sometimes want to fail fast. With the `timeout` argument you can now set it to something like 5 sec, and the request will fail if it takes longer than that.

## Checklist

- [x] I have updated the documentation
