### PR TITLE
feat: add logger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 node_modules
 bin
 .env
+.capter/logs

--- a/src/assert/assertions/to_be_above.rs
+++ b/src/assert/assertions/to_be_above.rs
@@ -4,7 +4,6 @@ use serde_json::Value;
 pub fn to_be_above(a: &Value, b: &Value, not: bool) -> Option<String> {
     if let (Some(a_number), Some(b_number)) = (utils::to_number(a), utils::to_number(b)) {
         let result = a_number > b_number;
-        // println!("hello {} {}", a_number, b_number);
         if utils::did_pass(result, not) {
             return None;
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ use globwalk;
 use serde_json::json;
 use ui::TerminalUi;
 use ureq;
-use utils::exit_with_code;
+use utils::{exit_with_code, Logger};
 use workflow::{workflow_result::WorkflowResult, RunSource, WorkflowConfig};
 
 pub struct CliOptions {
@@ -113,6 +113,12 @@ fn main() {
         }
 
         terminal_ui.summarize(&workflow_runs);
+
+        // write to log on fail
+        if !passed {
+            let mut logger = Logger::new();
+            logger.log_workflow_results(&workflow_runs);
+        }
 
         let webhook = match webhook {
             Some(val) => Some(val),

--- a/src/utils/http_request.rs
+++ b/src/utils/http_request.rs
@@ -181,8 +181,6 @@ mod tests {
         "};
         let config: Value = from_str(yaml).unwrap();
 
-        println!("{:#?}", config["body"]);
-
         request.add_body(&config["body"]);
 
         let response = request.call();

--- a/src/utils/logger.rs
+++ b/src/utils/logger.rs
@@ -1,0 +1,75 @@
+use crate::workflow::workflow_result::WorkflowResult;
+use fs::OpenOptions;
+use serde_json::json;
+use std::{fs, io::Write};
+
+pub struct Logger {}
+
+impl Logger {
+    pub fn new() -> Logger {
+        Logger {}
+    }
+
+    pub fn log_workflow_results(&mut self, workflow_results: &Vec<WorkflowResult>) {
+        fs::create_dir_all(".capter/logs").unwrap();
+
+        for workflow in workflow_results {
+            if workflow.passed {
+                continue;
+            }
+
+            let workflow_path = &workflow.file.clone().unwrap();
+            let workflow_name = workflow_path.split("/").last().unwrap();
+
+            let file_path = format!(".capter/logs/{}.log", &workflow_name);
+
+            // make sure we have a clean log file
+            let mut file = OpenOptions::new()
+                .write(true)
+                .create(true)
+                .open(file_path)
+                .unwrap();
+
+            // empty file
+            file.set_len(0).unwrap();
+
+            // title
+            write!(file, "{} [{}]\n\n", workflow.name, &workflow_path).unwrap();
+            write!(file, "Steps:\n\n").unwrap();
+
+            for request in &workflow.requests {
+                let step_passed = !request
+                    .response
+                    .clone()
+                    .unwrap()
+                    .assertion_results
+                    .iter()
+                    .any(|r| r.passed == false);
+
+                write!(file, "  Name:\n    {}\n\n", request.name).unwrap();
+                write!(file, "  Passed:\n    {}\n\n", step_passed).unwrap();
+                write!(file, "  Created at:\n    {}\n\n", request.created_at).unwrap();
+                write!(file, "  URL:\n    {} {}\n\n", request.method, request.url).unwrap();
+                write!(file, "  Query:\n    {}\n\n", json!(request.query)).unwrap();
+                write!(file, "  Headers:\n    {}\n\n", json!(request.headers)).unwrap();
+                write!(file, "  Body:\n    {}\n\n", json!(request.body)).unwrap();
+
+                let response = request.response.clone().unwrap();
+                write!(file, "  Response:\n\n").unwrap();
+                write!(file, "    Status:\n      {}\n\n", json!(response.status)).unwrap();
+                write!(
+                    file,
+                    "    Status text:\n      {}\n\n",
+                    json!(response.status_text)
+                )
+                .unwrap();
+                write!(file, "    Headers:\n      {}\n\n", json!(response.headers)).unwrap();
+                write!(file, "    Body:\n      {}\n\n", json!(response.body)).unwrap();
+
+                write!(file, "  ---\n\n").unwrap();
+            }
+
+            write!(file, "---\n\n").unwrap();
+        }
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,7 +1,9 @@
 pub mod deep_replace;
 pub mod exit;
 pub mod http_request;
+pub mod logger;
 
 pub use deep_replace::deep_replace;
 pub use exit::exit_with_code;
 pub use http_request::HttpRequest;
+pub use logger::Logger;


### PR DESCRIPTION
## Overview

- Log to a file whenever a workflow fails

## Details

It needs to be easy to figure out why a workflow is failing when using capter locally during development. This PR adds a logger that will log the request and response of failed workflows.

They end up in `.capter/logs`, and there will be one file for each failed workflow.

## Checklist

- [ ] I have added tests for new features
- [x] I have updated the documentation
