### PR TITLE
feat: add support for generic headers in workflow

### DIFF
--- a/.capter/graphql.yml
+++ b/.capter/graphql.yml
@@ -1,4 +1,4 @@
-name: graphql-inline
+name: graphql
 url: https://fake-api.capter.io/api/graphql
 steps:
   - name: fetch all posts

--- a/src/workflow/config.rs
+++ b/src/workflow/config.rs
@@ -22,6 +22,7 @@ pub struct WorkflowConfig {
     pub name: String,
     pub url: Option<String>,
     pub method: Option<String>,
+    pub headers: Option<BTreeMap<String, serde_yaml::Value>>,
     pub env: Option<BTreeMap<String, serde_yaml::Value>>,
     pub steps: Vec<WorkflowConfigStep>,
     pub skip: Option<bool>,


### PR DESCRIPTION
## Overview

- Add generic headers to workflows

## Details

Sometimes you want to pass headers to every request. For example "content-type" or "authorization". This PR add support for adding that:

```yml
name: headers
headers:
  authorization: Bearer ${{ env.token }}
steps:
  - name: step 1
    headers:
       foo: bar
```

This will merge the workflow headers with the step headers:

```yml
headers:
  authorization: Bearer ${{ env.token }}
  foo: bar
```

## Checklist

- [x] I have added tests for new features
- [x] I have updated the documentation
