### PR TITLE
feat: read github actions event file

### DIFF
--- a/src/workflow/config.rs
+++ b/src/workflow/config.rs
@@ -1,3 +1,4 @@
+use crate::utils::exit_with_code;
 use path_clean::PathClean;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -5,8 +6,6 @@ use std::{
     fs,
     path::PathBuf,
 };
-
-use crate::utils::exit_with_code;
 
 /// A `WorkflowConfig` is the struct we convert the yaml files into.
 ///

--- a/src/workflow/run_source.rs
+++ b/src/workflow/run_source.rs
@@ -1,8 +1,8 @@
 use crate::CliOptions;
 use last_git_commit::LastGitCommit;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_json::json;
-use std::env;
+use std::{env, fs};
 
 #[derive(Debug, Serialize)]
 #[allow(non_camel_case_types)]
@@ -15,6 +15,29 @@ impl Default for Source {
     fn default() -> Self {
         Source::cli
     }
+}
+
+/// Partial of the event payload on GitHub Actions
+///
+/// There's a lot of extra information in `workflow/event.json` that
+/// we can use to display useful information to the user. We read it
+/// through the `GITHUB_EVENT_PATH` environment variable.
+#[derive(Deserialize, Serialize, Debug)]
+struct GitHubActionsEventPayload {
+    action: Option<String>,
+    after: Option<String>,
+    before: Option<String>,
+    number: Option<i32>,
+    pull_request: Option<GitHubActionsPullReqeustPayload>,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+struct GitHubActionsPullReqeustPayload {
+    after: Option<String>,
+    before: Option<String>,
+    id: Option<i32>,
+    number: Option<i32>,
+    title: Option<String>,
 }
 
 /// Information about where the run was excecuted. It will
@@ -65,15 +88,44 @@ impl RunSource {
         if source.ci == Some("GitHub Actions".to_string()) {
             source.sha = Some(env::var("GITHUB_SHA").unwrap());
             source.repository = Some(env::var("GITHUB_REPOSITORY").unwrap());
-            source.meta = Some(json!({
-                "GITHUB_HEAD_REF": env::var("GITHUB_HEAD_REF").unwrap(),
-                "GITHUB_BASE_REF": env::var("GITHUB_BASE_REF").unwrap(),
-                "GITHUB_WORKFLOW": env::var("GITHUB_WORKFLOW").unwrap(),
-                "GITHUB_RUN_ID": env::var("GITHUB_RUN_ID").unwrap(),
-                "GITHUB_ACTOR": env::var("GITHUB_ACTOR").unwrap(),
-            }))
+            let mut meta = json!({
+                "env": {
+                    "GITHUB_HEAD_REF": env::var("GITHUB_HEAD_REF").unwrap(),
+                    "GITHUB_BASE_REF": env::var("GITHUB_BASE_REF").unwrap(),
+                    "GITHUB_WORKFLOW": env::var("GITHUB_WORKFLOW").unwrap(),
+                    "GITHUB_RUN_ID": env::var("GITHUB_RUN_ID").unwrap(),
+                    "GITHUB_ACTOR": env::var("GITHUB_ACTOR").unwrap(),
+                }
+            });
+
+            // try to read event file
+            if let Some(event) = read_github_workflow_event() {
+                meta["event"] = json!(event);
+            }
+
+            source.meta = Some(meta);
         }
 
         source
     }
+}
+
+/// Reads the event.json file in GitHub Actions.
+///
+/// This file mimics the payload you would get in a webhook from GitHub
+/// and what we are looking for here is mainly information about PRs,
+/// like number and title.
+fn read_github_workflow_event() -> Option<GitHubActionsEventPayload> {
+    let path = env::var("GITHUB_EVENT_PATH").unwrap();
+
+    return match fs::read_to_string(&path) {
+        Ok(s) => {
+            if let Ok(payload) = serde_json::from_str(&s) {
+                return Some(payload);
+            }
+
+            None
+        }
+        _ => None,
+    };
 }


### PR DESCRIPTION
## Overview

- Reads the `event.json` file provided by GitHub actions

## Details

To be able to support pull requests comments we need to get some extra information from GitHub Actions. Currently we collect the `sha`, and when an action is triggered by the `pull_request` event, that sha is not the actual one used by head, so there won't be any PR connected to it.

By reading the `event.json` file provided by GitHub Actions we can get the PR number, which is the one we need. We can also get the PR title which will be a nice addition to the web app.
 