### PR TITLE
feat: dotenv

### DIFF
--- a/.capter/errors.yml
+++ b/.capter/errors.yml
@@ -2,18 +2,18 @@ name: errors
 steps:
   - name: 500 error
     id: posts
-    url: GET https://fake-api.capter.io/api/errors/500
+    url: GET ${{ env.URL }}/api/errors/500
     assertions:
       - !expect status to_equal 500
 
   - name: 404 error
     id: posts
-    url: GET https://fake-api.capter.io/api/errors/404
+    url: GET ${{ env.URL }}/api/errors/404
     assertions:
       - !expect status to_equal 404
 
   - name: 301 error
     id: posts
-    url: GET https://fake-api.capter.io/api/errors/301
+    url: GET ${{ env.URL }}/api/errors/301
     assertions:
       - !expect status to_equal 301

--- a/.capter/graphql.yml
+++ b/.capter/graphql.yml
@@ -1,5 +1,5 @@
 name: graphql
-url: https://fake-api.capter.io/api/graphql
+url: ${{ env.URL }}/api/graphql
 steps:
   - name: fetch all posts
     id: posts

--- a/.capter/posts.yml
+++ b/.capter/posts.yml
@@ -6,7 +6,7 @@ env:
 steps:
   - name: fetch all posts
     id: posts
-    url: GET https://fake-api.capter.io/api/posts
+    url: GET ${{ env.URL }}/api/posts
     assertions:
       - !expect status to_equal 200
       - !!expect status to_equal 500
@@ -25,14 +25,14 @@ steps:
 
   - name: fetch one post
     id: post
-    url: GET https://fake-api.capter.io/api/posts/1
+    url: GET ${{ env.URL }}/api/posts/1
     assertions:
       - !expect status to_equal 200
       - !expect body.content to_match dicta dolor ut qui
       - !!expect body.id to_match 5
 
   - name: fetch all posts from author
-    url: GET https://fake-api.capter.io/api/posts
+    url: GET ${{ env.URL }}/api/posts
     query:
       authorId: ${{ post.response.body.authorId }}
     body:
@@ -46,7 +46,7 @@ steps:
       - !expect body.0.authorId to_equal ${{ mask post.response.body.id }}
 
   - name: fetch posts by user with id 20
-    url: GET https://fake-api.capter.io/api/posts
+    url: GET ${{ env.URL }}/api/posts
     query:
       authorId: 20
     assertions:
@@ -54,14 +54,14 @@ steps:
       - !expect body.0.authorId to_be_undefined
 
   - name: fetch author with id from env vars
-    url: GET https://fake-api.capter.io/api/authors/${{ env.AUTHOR_ID }}
+    url: GET ${{ env.URL }}/api/authors/${{ env.AUTHOR_ID }}
     skip: true
     assertions:
       - !expect status to_equal 200
       - !expect body.id to_equal ${{ env.AUTHOR_ID }}
 
   - name: create post
-    url: POST https://fake-api.capter.io/api/posts
+    url: POST ${{ env.URL }}/api/posts
     body:
       title: Post title
     assertions:

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -12,6 +12,8 @@ jobs:
     name: build-test
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, 'skip ci')"
+    env:
+      URL: https://fake-api.capter.io
     steps:
       - uses: actions/checkout@v2
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,12 +75,13 @@ checksum = "2e8c087f005730276d1096a652e92a8bacee2e2472bcc9715a74d2bec38b5820"
 
 [[package]]
 name = "capter"
-version = "1.0.0-alpha.26"
+version = "1.0.0-alpha.27"
 dependencies = [
  "chrono",
  "ci_info",
  "clap",
  "crossterm",
+ "dotenv",
  "exitcode",
  "globwalk",
  "indoc",
@@ -208,6 +209,12 @@ name = "difference"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
+
+[[package]]
+name = "dotenv"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 
 [[package]]
 name = "dtoa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "capter"
-version = "1.0.0-alpha.26"
+version = "1.0.0-alpha.27"
 authors = ["capter.io <filip@capter.io>"]
 license = "MIT"
 description = "Capter is a lightweight end-to-end testing tool for APIs."
@@ -29,6 +29,7 @@ globwalk = "0.8.1"
 path-clean = "0.1.0"
 ureq = { version = "2.0.1", features = ["json"] }
 exitcode = "1.1.2"
+dotenv = "0.15.0"
 
 [dev-dependencies]
 indoc = "1.0"

--- a/installers/npm/binary-install.js
+++ b/installers/npm/binary-install.js
@@ -3,20 +3,11 @@ const { join } = require('path');
 const { spawnSync } = require('child_process');
 const axios = require('axios');
 const rimraf = require('rimraf');
-require('dotenv').config({ path: require('find-config')('.env') });
-
-const TOKEN = process.env.GITHUB_TOKEN;
 
 const error = (msg) => {
   console.error(msg);
   process.exit(1);
 };
-
-if (!process.env.GITHUB_TOKEN) {
-  return error(
-    '⚠️  failed to install capter\n   no `GITHUB_TOKEN` found in .env\n   add it and run install again\n'
-  );
-}
 
 class Binary {
   constructor(name, repo, version, target) {
@@ -24,8 +15,7 @@ class Binary {
     this.repo = repo;
     this.version = version;
     this.target = target;
-    //npm.pkg.github.com
-    https: this.installDirectory = join(__dirname, 'bin');
+    this.installDirectory = join(__dirname, 'bin');
 
     if (!existsSync(this.installDirectory)) {
       mkdirSync(this.installDirectory, { recursive: true });
@@ -47,7 +37,6 @@ class Binary {
       url: `https://api.github.com/repos/${this.repo}/releases`,
       headers: {
         Accept: 'application/vnd.github.v3.raw',
-        authorization: `token ${TOKEN}`,
       },
     })
       .then((res) => {
@@ -60,7 +49,6 @@ class Binary {
           url: `https://api.github.com/repos/${this.repo}/releases/assets/${assetId}`,
           responseType: 'stream',
           headers: {
-            authorization: `token ${TOKEN}`,
             Accept: 'application/octet-stream',
           },
         })

--- a/installers/npm/binary-install.js
+++ b/installers/npm/binary-install.js
@@ -33,38 +33,19 @@ class Binary {
 
     console.log(`downloading binary from ${this.repo}...`);
 
+    const url = `https://github.com/capterqa/cli/releases/download/v${this.version}/${this.name}-v${this.version}-${this.target}`;
+
     return axios({
-      url: `https://api.github.com/repos/${this.repo}/releases`,
-      headers: {
-        Accept: 'application/vnd.github.v3.raw',
-      },
+      url,
+      responseType: 'stream',
     })
       .then((res) => {
-        var release = res.data[0];
-        var asset = release.assets.find((r) => {
-          return r.name.includes(this.target);
-        });
-        var assetId = asset.id;
-        return axios({
-          url: `https://api.github.com/repos/${this.repo}/releases/assets/${assetId}`,
-          responseType: 'stream',
-          headers: {
-            Accept: 'application/octet-stream',
-          },
-        })
-          .then((res) => {
-            res.data.pipe(
-              createWriteStream(`${this.installDirectory}/${this.name}`, {
-                mode: 0o755,
-              })
-            );
+        console.log(`${this.name} has been installed!`);
+        res.data.pipe(
+          createWriteStream(`${this.installDirectory}/${this.name}`, {
+            mode: 0o755,
           })
-          .then(() => {
-            console.log(`${this.name} has been installed!`);
-          })
-          .catch((e) => {
-            error(`error fetching release: ${e.message}`);
-          });
+        );
       })
       .catch((e) => {
         error(`error fetching release: ${e.message}`);

--- a/installers/npm/binary.js
+++ b/installers/npm/binary.js
@@ -8,7 +8,7 @@ const error = (msg) => {
   process.exit(1);
 };
 
-const { version, repository } = require('./package.json');
+const { version } = require('./package.json');
 let name = 'capter';
 
 const supportedPlatforms = [

--- a/installers/npm/package-lock.json
+++ b/installers/npm/package-lock.json
@@ -1,19 +1,17 @@
 {
-  "name": "@capterqa/cli",
+  "name": "capter",
   "version": "1.0.0-alpha.26",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@capterqa/cli",
-      "version": "1.0.0-alpha.14",
+      "name": "capter",
+      "version": "1.0.0-alpha.26",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "axios": "^0.21.1",
         "console.table": "^0.10.0",
-        "dotenv": "^8.2.0",
-        "find-config": "^1.0.0",
         "rimraf": "^3.0.2"
       },
       "bin": {
@@ -76,14 +74,6 @@
         "clone": "^1.0.2"
       }
     },
-    "node_modules/dotenv": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
-      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/easy-table": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/easy-table/-/easy-table-1.1.0.tgz",
@@ -93,17 +83,6 @@
       },
       "optionalDependencies": {
         "wcwidth": ">=1.0.1"
-      }
-    },
-    "node_modules/find-config": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/find-config/-/find-config-1.0.0.tgz",
-      "integrity": "sha1-6vorm8B/qckOmgw++c7PHMgA9TA=",
-      "dependencies": {
-        "user-home": "^2.0.0"
-      },
-      "engines": {
-        "node": ">= 0.12"
       }
     },
     "node_modules/follow-redirects": {
@@ -182,14 +161,6 @@
         "wrappy": "1"
       }
     },
-    "node_modules/os-homedir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -210,17 +181,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/user-home": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
-      "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
-      "dependencies": {
-        "os-homedir": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/wcwidth": {
@@ -289,25 +249,12 @@
         "clone": "^1.0.2"
       }
     },
-    "dotenv": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
-      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
-    },
     "easy-table": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/easy-table/-/easy-table-1.1.0.tgz",
       "integrity": "sha1-hvmrTBAvA3G3KXuSplHVgkvIy3M=",
       "requires": {
         "wcwidth": ">=1.0.1"
-      }
-    },
-    "find-config": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/find-config/-/find-config-1.0.0.tgz",
-      "integrity": "sha1-6vorm8B/qckOmgw++c7PHMgA9TA=",
-      "requires": {
-        "user-home": "^2.0.0"
       }
     },
     "follow-redirects": {
@@ -363,11 +310,6 @@
         "wrappy": "1"
       }
     },
-    "os-homedir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
-    },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -379,14 +321,6 @@
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
       "requires": {
         "glob": "^7.1.3"
-      }
-    },
-    "user-home": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
-      "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
-      "requires": {
-        "os-homedir": "^1.0.0"
       }
     },
     "wcwidth": {

--- a/installers/npm/package.json
+++ b/installers/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capterqa/cli",
-  "version": "1.0.0-alpha.26",
+  "version": "1.0.0-alpha.27",
   "description": "Capter is a lightweight end-to-end testing tool for APIs.",
   "main": "index.js",
   "author": "capter.io <filip@capter.io>",
@@ -24,8 +24,6 @@
   "dependencies": {
     "axios": "^0.21.1",
     "console.table": "^0.10.0",
-    "dotenv": "^8.2.0",
-    "find-config": "^1.0.0",
     "rimraf": "^3.0.2"
   }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod utils;
 mod workflow;
 
 use clap::{crate_version, load_yaml, App, AppSettings};
+use dotenv::dotenv;
 use globwalk;
 use serde_json::json;
 use ui::TerminalUi;
@@ -28,6 +29,9 @@ impl Default for CliOptions {
 }
 
 fn main() {
+    // read .env file
+    dotenv().ok();
+
     let yml = load_yaml!("cli.yml");
     let matches = App::from_yaml(yml)
         .setting(AppSettings::SubcommandRequiredElseHelp)


### PR DESCRIPTION
## Overview

- Read `.env` file
- Update the npm package to reflect that the repo is now public

## Details

Adding support for `.env` files makes it a lot easier to handle environment variables. The CLI will now read the .env using the [`dotenv` crate](https://crates.io/crates/dotenv).

## Checklist

- [x] I have updated the documentation
