### PR TITLE
feat: add init command

### DIFF
--- a/src/cli.yml
+++ b/src/cli.yml
@@ -2,6 +2,8 @@ name: capter
 author: capter.io <capter.io>
 about: Test your APIs.
 subcommands:
+  - init:
+      about: creates an example workflow
   - test:
       about: run tests
       args:

--- a/src/main.rs
+++ b/src/main.rs
@@ -171,4 +171,11 @@ fn main() {
             exit_with_code(1, None);
         }
     }
+
+    // handle the subcommand `test`
+    if matches.subcommand_matches("init").is_some() {
+        WorkflowConfig::create_example();
+        TerminalUi::print_init();
+        exit_with_code(exitcode::OK, None);
+    }
 }

--- a/src/ui/ui.rs
+++ b/src/ui/ui.rs
@@ -90,4 +90,29 @@ impl TerminalUi {
     fn format_attr(key: &str, val: &Value) -> String {
         format!("  {}: {}\n", &key, &val.clone())
     }
+
+    pub fn print_init() {
+        execute!(
+            stdout(),
+            SetAttribute(Attribute::Bold),
+            Print("\nWelcome to Capter!\n"),
+            SetAttribute(Attribute::Reset),
+            Print("\nWe've created a workflow in "),
+            SetAttribute(Attribute::Underlined),
+            Print(".capter/example.test.yml"),
+            SetAttribute(Attribute::Reset),
+            Print("\n"),
+            Print("Run it by calling: "),
+            SetAttribute(Attribute::Bold),
+            Print("capter test --token [TOKEN]"),
+            SetAttribute(Attribute::Reset),
+            Print("\n\n"),
+            Print("For more information, go to https://docs.capter.io or call: "),
+            SetAttribute(Attribute::Bold),
+            Print("capter test --help"),
+            Print("\n"),
+            SetAttribute(Attribute::Reset),
+        )
+        .unwrap();
+    }
 }


### PR DESCRIPTION
## Overview

- Add `init` command

## Details

The `init` creates an example workflow to make it super easy for users to start using Capter. The onboarding flow can now be:

```sh
$ npm i capter --save-dev
$ npx capter init
$ npx capter test --token [TOKEN]
```

## Checklist

- [ ] I have added tests for new features
- [ ] I have updated the documentation
