### PR TITLE
feat: show run url when finished

### DIFF
--- a/.capter/posts.yml
+++ b/.capter/posts.yml
@@ -35,12 +35,6 @@ steps:
     url: GET ${{ env.URL }}/api/posts
     query:
       authorId: ${{ post.response.body.authorId }}
-    body:
-      id: ${{ mask post.response.body.title }}
-      nested:
-        what:
-          - ${{ post.response.body.authorId }}
-          - ${{ mask post.response.body.authorId }}
     assertions:
       - !expect status to_equal 200
       - !expect body.0.authorId to_equal ${{ mask post.response.body.id }}

--- a/src/ui/webhook.rs
+++ b/src/ui/webhook.rs
@@ -1,4 +1,4 @@
-use crate::ui::TerminalUi;
+use crate::{ui::TerminalUi, WebhookResponse};
 use crossterm::{
     execute,
     style::{Attribute, Color, Print, SetAttribute, SetForegroundColor},
@@ -18,18 +18,18 @@ impl TerminalUi {
         .unwrap();
     }
 
-    pub fn webhook_start(&self, url: &str) {
+    pub fn webhook_start(&self) {
         execute!(
             stdout(),
             SetAttribute(Attribute::Dim),
             Print("\n---\n\n"),
-            Print(format!("Posting to webhook [{}]... ", url)),
+            Print("Posting result... "),
             SetAttribute(Attribute::Reset),
         )
         .unwrap();
     }
 
-    pub fn webhook_done(&self) {
+    pub fn webhook_done(&self, webhook_response: Option<WebhookResponse>) {
         execute!(
             stdout(),
             SetForegroundColor(Color::Green),
@@ -43,6 +43,20 @@ impl TerminalUi {
             SetAttribute(Attribute::Reset),
         )
         .unwrap();
+
+        if let Some(webhook_response) = webhook_response {
+            let url = webhook_response.url;
+            execute!(
+                stdout(),
+                SetAttribute(Attribute::Dim),
+                Print("\n---\n\n"),
+                Print("Inspect run: "),
+                Print(url),
+                Print("\n"),
+                SetAttribute(Attribute::Reset),
+            )
+            .unwrap();
+        }
     }
     pub fn webhook_error(&self, error: &str) {
         execute!(


### PR DESCRIPTION
## Overview

- Shows a URL to the run if the webhook return a `url` property

## Details

To make it easier for the user to debug errors when using capter.io or their own webhook, the CLI will now display the `url` property if it's returned from the webhook:

```sh
---

Posting result... ✓
done! ✨

---

Inspect run: http://capter.io/xyz
```
